### PR TITLE
Add onRemove handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,15 @@ module.exports = window.L.LayerGroup.extend({
             }
         }
     },
+    
+    
+    onRemove: function (map) {
+        L.LayerGroup.prototype.onRemove.call(this, map); //call parent
+
+        map
+            .off('viewreset', this._load, this)
+            .off('moveend', this._load, this);
+    },
 
     _icon: function(fp) {
         fp = fp || {};


### PR DESCRIPTION
Fixes "map is null" error after disabling the layer in layer swither:


![obrazek](https://cloud.githubusercontent.com/assets/155542/24847749/3de52dea-1dc3-11e7-8181-13a524f70b29.png)



We had this issue here: https://github.com/osmcz/osmcz/issues/165

See result here:
https://openstreetmap.cz/#map=14/50.0940/14.3929&layers=xN
